### PR TITLE
Add support for req.new -newkey command

### DIFF
--- a/lib/openssl-wrapper.js
+++ b/lib/openssl-wrapper.js
@@ -17,6 +17,7 @@ var expected = {
   'smime.verify': '^verification successful',
   'cms.verify': '^verification successful',
   'req.verify': '^verify ok',
+  'req.new': '^generating',
   'x509.req': '^signature ok',
   'genrsa': '^generating',
   'pkcs12': '^mac verified ok',


### PR DESCRIPTION
Fix error with command: openssl-wrapper > openssl req -new -newkey rsa:2048 -nodes -out vunb.csr -keyout vunb.key -subj /CN=Vunb