### PR TITLE
Incorrect example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ return openssl('genrsa', {des3: true, passout: `pass:${password}`, '2048': false
 ``` javascript
 import Promise from 'bluebird';
 import openssl from 'openssl-wrapper';
-const opensslAsync = Promise.promisify(openssl.exec);
+const opensslAsync = Promise.promisify(openssl);
 
 // Extract enveloped data
 return opensslAsync('cms.verify', signedData, {inform: 'DER', noverify: true})


### PR DESCRIPTION
Look up  the [default](https://github.com/mgcrea/node-openssl-wrapper/blob/master/src/index.js#L17) exported thing in your source code, it's the `exec` function, so can not resolve `openssl.exec` as shown in the example code.
